### PR TITLE
unittest2 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ ipython==4.0.0
 ipdb==0.8.1
 extras==0.0.3
 python-mimeparse==0.1.4
+unittest2==1.1.0
 testtools==1.8.0
 testscenarios==0.5.0
 python-subunit==1.1.0


### PR DESCRIPTION
for some reason the docker wheel build step was pulling in unittest2 1.0.0
on jenkins and that is failing. explicitly upgrading to 1.1.0 seems
to fix the issue.