### PR TITLE
new mathjax CDN URL

### DIFF
--- a/capsim/templates/main/model.html
+++ b/capsim/templates/main/model.html
@@ -181,7 +181,7 @@ $$ \text{food-literacy} = \Gamma(0.5, 0.10) $$
 {% endblock %}
 {% block js %}
 <script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
 {% endblock %}

--- a/capsim/templates/sim/topic-obesity-debrief.html
+++ b/capsim/templates/sim/topic-obesity-debrief.html
@@ -201,7 +201,7 @@ $$ \text{food-literacy} = \Gamma(0.5, 0.10) $$
 
 {% block js %}
 <script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
 {% endblock %}


### PR DESCRIPTION
https://www.mathjax.org/cdn-shutting-down/