### PR TITLE
fix pandas deprecation warning

### DIFF
--- a/capsim/sim/logic.py
+++ b/capsim/sim/logic.py
@@ -393,7 +393,7 @@ class RunOutput(object):
     def __init__(self, ticks, params, data):
         self.ticks = ticks
         self.params = params
-        self.data = pd.DataFrame(data).sort(['tick'])
+        self.data = pd.DataFrame(data).sort_values(by=['tick'])
 
     def to_dict(self):
         return dict(


### PR DESCRIPTION
Pandas was raising a deprecation warning:

```
./capsim/capsim/sim/logic.py:396: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)
```

Looks like they just renamed a method.