### PR TITLE
update mathjax CDN URL

### DIFF
--- a/capsim/templates/sim/topic-obesity-debrief.html
+++ b/capsim/templates/sim/topic-obesity-debrief.html
@@ -200,8 +200,8 @@ $$ \text{food-literacy} = \Gamma(0.5, 0.10) $$
 {% endblock %}
 
 {% block js %}
-<script type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
 {% endblock %}


### PR DESCRIPTION
'latest' doesn't seem to work with the new cdnjs URL