### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
   - "2.7.6"
   - "2.7"
+  - "3.6"
 install:
   - pip install -U pip==9.0.3
   - pip install -U wheel

--- a/capsim/main/forms.py
+++ b/capsim/main/forms.py
@@ -263,7 +263,7 @@ class ExperimentForm(forms.Form):
 
     independent_variable = forms.ChoiceField(
         initial="gamma_1",
-        choices=zip(FLOAT_FIELDS, FLOAT_FIELDS),
+        choices=list(zip(FLOAT_FIELDS, FLOAT_FIELDS)),
         label="Independent Variable",
         )
     independent_min = forms.FloatField(
@@ -284,7 +284,7 @@ class ExperimentForm(forms.Form):
 
     dependent_variable = forms.ChoiceField(
         initial="gamma_2",
-        choices=zip(FLOAT_FIELDS, FLOAT_FIELDS),
+        choices=list(zip(FLOAT_FIELDS, FLOAT_FIELDS)),
         label="Dependent Variable",
         )
     dependent_min = forms.FloatField(

--- a/capsim/main/tests/__init__.py
+++ b/capsim/main/tests/__init__.py
@@ -1,3 +1,0 @@
-# flake8: noqa
-from test_models import *
-from test_views import *

--- a/capsim/main/tests/test_views.py
+++ b/capsim/main/tests/test_views.py
@@ -22,7 +22,7 @@ class BasicViewTest(TestCase):
     def test_root_post_invalid(self):
         response = self.c.post("/run/new/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("errorlist" in response.content)
+        self.assertContains(response, "errorlist")
 
     def test_root_post_valid(self):
         response = self.c.post(

--- a/capsim/main/views.py
+++ b/capsim/main/views.py
@@ -23,7 +23,7 @@ class LoggedInMixin(object):
 
 def apply_skews(request, skew_params):
     i_s = settings.INTERVENTION_SKEWS
-    for k in request.POST.keys():
+    for k in list(request.POST.keys()):
         if not k.startswith('intervention_'):
             continue
         v = request.POST[k]

--- a/capsim/settings.py
+++ b/capsim/settings.py
@@ -1,7 +1,7 @@
 # flake8: noqa
-from settings_shared import *
+from capsim.settings_shared import *
 
 try:
-    from local_settings import *
+    from capsim.local_settings import *
 except ImportError:
     pass

--- a/capsim/settings_compose.py
+++ b/capsim/settings_compose.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from settings_shared import *
+from capsim.settings_shared import *
 
 DEBUG = True
 DATABASES = {
@@ -17,6 +17,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 BROKER_URL = "amqp://guest:guest@rabbitmq:5672/"
 
 try:
-    from local_settings import *
+    from capsim.local_settings import *
 except ImportError:
     pass

--- a/capsim/settings_docker.py
+++ b/capsim/settings_docker.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from settings_shared import *
+from capsim.settings_shared import *
 
 # required settings:
 SECRET_KEY = os.environ['SECRET_KEY']

--- a/capsim/settings_production.py
+++ b/capsim/settings_production.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from settings_shared import *
+from capsim.settings_shared import *
 from ccnmtlsettings.production import common
 
 locals().update(
@@ -12,6 +12,6 @@ locals().update(
     ))
 
 try:
-    from local_settings import *
+    from capsim.local_settings import *
 except ImportError:
     pass

--- a/capsim/settings_staging.py
+++ b/capsim/settings_staging.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from settings_shared import *
+from capsim.settings_shared import *
 from ccnmtlsettings.staging import common
 
 locals().update(
@@ -12,6 +12,6 @@ locals().update(
     ))
 
 try:
-    from local_settings import *
+    from capsim.local_settings import *
 except ImportError:
     pass

--- a/capsim/sim/paramset.py
+++ b/capsim/sim/paramset.py
@@ -1,5 +1,5 @@
 import numpy as np
-import defaults
+from capsim.sim import defaults
 
 
 class NormalVarParams(object):

--- a/capsim/sim/tasks.py
+++ b/capsim/sim/tasks.py
@@ -1,12 +1,13 @@
 from celery.decorators import task
 from django_statsd.clients import statsd
+from django.utils.encoding import smart_text
 from .models import Experiment, ExpRun, RunRecord, RunOutputRecord
 
 
 @task
 def run_experiment(experiment_id):
     statsd.incr("run_experiment")
-    print "running experiment %d" % experiment_id
+    print("running experiment %d" % experiment_id)
     e = Experiment.objects.get(id=experiment_id)
     e.populate(callback=process_run.delay)
 
@@ -14,7 +15,7 @@ def run_experiment(experiment_id):
 @task
 def generate_full_csv(experiment_id):
     statsd.incr("generate_full_csv")
-    print "generating full csv"
+    print("generating full csv")
     e = Experiment.objects.get(id=experiment_id)
     e.write_csv()
 
@@ -22,7 +23,7 @@ def generate_full_csv(experiment_id):
 @task
 def process_run(run_id, exprun_id):
     statsd.incr("process_run")
-    print "process_run %d, %d" % (run_id, exprun_id)
+    print("process_run %d, %d" % (run_id, exprun_id))
     er = ExpRun.objects.get(id=exprun_id)
     try:
         rr = RunRecord.objects.get(id=run_id)
@@ -31,7 +32,7 @@ def process_run(run_id, exprun_id):
         ror = RunOutputRecord(run=rr)
         ror.from_runoutput(out)
         er.completed(ror)
-    except Exception, e:
-        print "run failed: "
-        print str(e)
+    except Exception as e:
+        print("run failed: ")
+        print(smart_text(e))
         er.failed()

--- a/capsim/sim/tests/__init__.py
+++ b/capsim/sim/tests/__init__.py
@@ -1,4 +1,0 @@
-# flake8: noqa
-from .test_logic import *
-from .test_models import *
-from .test_views import *

--- a/capsim/sim/tests/test_views.py
+++ b/capsim/sim/tests/test_views.py
@@ -20,14 +20,14 @@ class BasicViewTest(TestCase):
     def test_run_form(self):
         response = self.c.get("/run/new/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("id=\"test-new-run-form\"" in response.content)
+        self.assertContains(response, "id=\"test-new-run-form\"")
 
     def test_run_form_disabled(self):
         self.flag.everyone = False
         self.flag.save()
         response = self.c.get("/run/new/")
         self.assertEquals(response.status_code, 200)
-        self.assertFalse("id=\"test-new-run-form\"" in response.content)
+        self.assertNotContains(response, "id=\"test-new-run-form\"")
 
     def test_toggle_flag(self):
         response = self.c.post("/run/toggle/", dict())
@@ -38,7 +38,7 @@ class BasicViewTest(TestCase):
     def test_runs(self):
         response = self.c.get("/run/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("<p>No saved runs yet.</p>" in response.content)
+        self.assertContains(response, "<p>No saved runs yet.</p>")
 
     def test_run(self):
         u = User.objects.create(username='test')
@@ -50,7 +50,7 @@ class BasicViewTest(TestCase):
         ror.from_runoutput(out)
         response = self.c.get("/run/%d/" % rr.id)
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("<h2>Saved Run: " in response.content)
+        self.assertContains(response, "<h2>Saved Run: ")
 
     def test_edit_run(self):
         u = User.objects.create(username='test')
@@ -82,7 +82,7 @@ class BasicViewTest(TestCase):
         ror.from_runoutput(out)
         response = self.c.get("/run/compare/?run_%d=on" % rr.id)
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("makeGraph" in response.content)
+        self.assertContains(response, "makeGraph")
 
     def test_run_json(self):
         u = User.objects.create(username='test')
@@ -94,7 +94,7 @@ class BasicViewTest(TestCase):
         ror.from_runoutput(out)
         response = self.c.get("/run/%d/json/" % rr.id)
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("agents_mass" in response.content)
+        self.assertContains(response, "agents_mass")
 
 
 class ExperimentViewTest(TestCase):
@@ -117,7 +117,7 @@ class ExperimentViewTest(TestCase):
     def test_experiment_post_invalid(self):
         response = self.c.post("/experiment/new/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("errorlist" in response.content)
+        self.assertContains(response, "errorlist")
 
     def test_experiment_post_valid(self):
         response = self.c.post(
@@ -174,7 +174,7 @@ class ExperimentViewTest(TestCase):
         er = ExpRunFactory()
         r = self.c.get(er.experiment.get_absolute_url() + "delete/")
         self.assertEqual(r.status_code, 200)
-        self.assertTrue("<form" in r.content)
+        self.assertContains(r, "<form")
         r = self.c.post(er.experiment.get_absolute_url() + "delete/")
         self.assertEqual(r.status_code, 302)
 
@@ -193,7 +193,7 @@ class InterventionViewTest(TestCase):
         more granular unit tests later"""
         response = self.c.get("/calibrate/intervention/add/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("<form" in response.content)
+        self.assertContains(response, "<form")
 
         response = self.c.post(
             "/calibrate/intervention/add/",
@@ -203,7 +203,7 @@ class InterventionViewTest(TestCase):
         self.assertEquals(response.status_code, 302)
 
         response = self.c.get("/calibrate/intervention/")
-        self.assertTrue("new intervention" in response.content)
+        self.assertContains(response, "new intervention")
 
         i = Intervention.objects.all()[0]
         response = self.c.post(
@@ -215,7 +215,7 @@ class InterventionViewTest(TestCase):
             })
         self.assertEquals(response.status_code, 302)
         response = self.c.get("/calibrate/intervention/")
-        self.assertTrue("400" in response.content)
+        self.assertContains(response, "400")
 
         response = self.c.get(i.get_absolute_url())
         self.assertEquals(response.status_code, 200)
@@ -242,7 +242,7 @@ class ParameterViewTest(TestCase):
         more granular unit tests later"""
         response = self.c.get("/calibrate/parameter/add/")
         self.assertEquals(response.status_code, 200)
-        self.assertTrue("<form" in response.content)
+        self.assertContains(response, "<form")
 
         response = self.c.post(
             "/calibrate/parameter/add/",
@@ -251,7 +251,7 @@ class ParameterViewTest(TestCase):
         self.assertEquals(response.status_code, 302)
 
         response = self.c.get("/calibrate/parameter/")
-        self.assertTrue("new_parameter" in response.content)
+        self.assertContains(response, "new_parameter")
 
         p = Parameter.objects.all()[0]
         response = self.c.post(
@@ -261,7 +261,7 @@ class ParameterViewTest(TestCase):
                  ))
         self.assertEquals(response.status_code, 302)
         response = self.c.get("/calibrate/parameter/")
-        self.assertTrue("2.0" in response.content)
+        self.assertContains(response, "2.0")
 
         response = self.c.get(p.get_absolute_url())
         self.assertEquals(response.status_code, 200)

--- a/capsim/sim/views.py
+++ b/capsim/sim/views.py
@@ -86,7 +86,7 @@ class InterventionAddView(LoggedInMixin, View):
 
 class InterventionSetCostsView(LoggedInMixin, View):
     def post(self, request):
-        for k in request.POST.keys():
+        for k in list(request.POST.keys()):
             (level, _, intervention_id) = k.split("_")
             cost = request.POST.get(k, "0")
             i = Intervention.objects.get(pk=intervention_id)
@@ -109,7 +109,7 @@ class InterventionEditView(LoggedInMixin, View):
     def post(self, request, pk):
         intervention = get_object_or_404(self.model, pk=pk)
         intervention.clear_all_modifiers()
-        for k in request.POST.keys():
+        for k in list(request.POST.keys()):
             (level, t, n) = k.split("_")
             if t != "parameter":
                 continue
@@ -153,7 +153,7 @@ class CompareRunsView(LoggedInMixin, TemplateView):
 
     def get_context_data(self):
         runs = []
-        for k in self.request.GET.keys():
+        for k in list(self.request.GET.keys()):
             if not k.startswith('run'):
                 continue
             id = k.split('_')[1]

--- a/django.mk
+++ b/django.mk
@@ -18,7 +18,8 @@ REQUIREMENTS ?= requirements.txt
 SYS_PYTHON ?= python
 PIP ?= $(VE)/bin/pip
 PY_SENTINAL ?= $(VE)/sentinal
-WHEEL_VERSION ?= 0.31.0
+WHEEL_VERSION ?= 0.32.3
+PIP_VERSION ?= 18.1
 VIRTUALENV ?= virtualenv.py
 SUPPORT_DIR ?= requirements/virtualenv_support/
 MAX_COMPLEXITY ?= 10
@@ -31,6 +32,8 @@ jenkins: check flake8 test eslint bandit
 $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)
 	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
+	$(PIP) install pip==$(PIP_VERSION)
+	$(PIP) install --upgrade setuptools
 	$(PIP) install wheel==$(WHEEL_VERSION)
 	$(PIP) install --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
 	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pyparsing==2.3.0
 singledispatch==3.4.0.3
 backports-abc==0.5
 tornado==4.5.3 # pyup: < 5.0
-BeautifulSoup==3.2.1
 cssselect==1.0.3
 lxml==4.2.5
 sure==1.4.11
@@ -80,7 +79,6 @@ amqp==2.3.2
 
 amqplib==1.0.2
 kombu==3.0.37 # pyup: <4.0.0
-librabbitmq==2.0.0
 billiard==3.5.0.5
 celery==3.1.26.post2 # pyup: <4.0.0
 sqlparse==0.2.4
@@ -88,7 +86,6 @@ decorator==4.3.0
 boto==2.49.0
 contextlib2==0.5.5
 argparse==1.4.0
-wsgiref==0.1.2
 rcssmin==1.0.6
 rjsmin==1.0.12
 cycler==0.10.0
@@ -129,7 +126,7 @@ django-smtp-ssl==1.0
 subprocess32==3.5.3
 
 matplotlib==2.2.3 # pyup: <3.0.0
-pandas==0.22.0 # pyup: <0.23.0
+pandas==0.23.4 # pyup: <0.24.0
 
 ccnmtlsettings==1.4.0
 


### PR DESCRIPTION
Note that librabbitmq is removed: I was running into some compile errors that I was unable to solve, and it seems that the [py-amqp](https://github.com/celery/py-amqp), which was already included in the requirements.txt, may actually be recommended over librabbitmq: https://github.com/celery/librabbitmq/issues/118#issuecomment-385461136

py-amqp (actual package name is just amqp) is an API-compatible alternative to librabbitmq that just uses Python without any C requirements.