### PR TITLE
Add python 3.4 support for celery01

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 sudo: false
 python:
+  - "3.4"
   - "3.6"
 install:
   - pip install -U pip==19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,9 +51,11 @@ certifi==2019.6.16
 
 chardet==3.0.4
 idna==2.8
-urllib3==1.25.3
 
-requests==2.22.0
+urllib3==1.24.3 # pyup: <1.25
+requests==2.21.0 # pyup: <2.22.0
+# pinning requests here for python 3.4 support
+
 logilab-common==1.4.2
 logilab-astng==0.24.3
 editdistance==0.5.3
@@ -69,7 +71,10 @@ setuptools==41.0.1
 networkx==2.2 # pyup: <2.3
 ldap3==2.6
 olefile==0.46
-Pillow==6.0.0
+
+# for python 3.4
+Pillow==5.4.1 # pyup: <6.0.0
+
 mock==3.0.5
 anyjson==0.3.3
 
@@ -125,7 +130,9 @@ django-smtp-ssl==1.0
 subprocess32==3.5.4
 
 matplotlib==2.2.4 # pyup: <3.0.0
-pandas==0.23.4 # pyup: <0.24.0
+
+pandas==0.20.3 # pyup: <0.21.0
+# for python 3.4
 
 ccnmtlsettings==1.5.0
 


### PR DESCRIPTION
celery01 is still on python 3.4 - these libraries need to be downgraded
for python 3.4 support:

* requests
* Pillow
* pandas