### PR TITLE
downgrade to setuptools 41.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ numpy==1.16.4 # pyup: <1.17
 pytz==2019.2
 
 python-dateutil==2.8.0
-setuptools==41.1.0.post1
+setuptools==41.1.0
 
 networkx==2.2 # pyup: <2.3
 ldap3==2.6


### PR DESCRIPTION
41.1.0.post1 doesn't exist in pypi, causing build failure.