### PR TITLE
Upgrade to celery 4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,5 +8,8 @@ jobs:
           python-version: [3.6]
     steps:
       - uses: actions/checkout@v2
-      - name: Build with Makefile
-        run: make
+      - uses: nijel/rabbitmq-action@v1.0.0
+      - name: Run flake8
+        run: make flake8
+      - name: Run unit tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP=capsim
 JS_FILES=media/js/interventions.js media/js/graph.js
-MAX_COMPLEXITY=5
+MAX_COMPLEXITY=7
 
 all: jenkins
 

--- a/capsim/settings_shared.py
+++ b/capsim/settings_shared.py
@@ -1,6 +1,5 @@
 # Django settings for capsim project.
 import os.path
-import djcelery
 import sys
 from ccnmtlsettings.shared import common
 
@@ -16,11 +15,13 @@ PROJECT_APPS = [
 
 USE_TZ = True
 
-djcelery.setup_loader()
+CELERY_RESULT_BACKEND = 'django-db'
+CELERY_CACHE_BACKEND = 'django-cache'
+broker_url = "amqp://localhost:5672//capsim"
+worker_concurrency = 4
 
 if 'test' in sys.argv or 'jenkins' in sys.argv:
-    CELERY_ALWAYS_EAGER = True
-    BROKER_BACKEND = 'memory'
+    broker_url = 'memory://localhost/'
 
 
 INSTALLED_APPS += [  # noqa
@@ -33,9 +34,9 @@ INSTALLED_APPS += [  # noqa
     'quizblock',
     'capsim.main',
     'capsim.sim',
-    'djcelery',
     'sorl.thumbnail',
     'infranil',
+    'django_celery_results',
 ]
 
 PAGEBLOCKS = ['pageblocks.TextBlock',
@@ -45,9 +46,6 @@ PAGEBLOCKS = ['pageblocks.TextBlock',
               'pageblocks.ImagePullQuoteBlock',
               'quizblock.Quiz',
               ]
-
-BROKER_URL = "amqp://localhost:5672//capsim"
-CELERYD_CONCURRENCY = 4
 
 IPYTHON_ARGUMENTS = [
     '--pylab',

--- a/capsim/sim/__init__.py
+++ b/capsim/sim/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/capsim/sim/celery.py
+++ b/capsim/sim/celery.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'capsim.settings')
+
+app = Celery('capsim')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/capsim/sim/models.py
+++ b/capsim/sim/models.py
@@ -198,11 +198,27 @@ class Experiment(models.Model):
 
     def heatmap(self):
         data = []
+        empty_map = {
+            'data': [],
+            'min': 0,
+            'max': 0
+        }
+
         for er in self.exprun_set.all():
-            data.append(dict(ind=er.independent_value, dep=er.dependent_value,
-                             trial=er.trial, mass=er.mass))
+            data.append(dict(
+                ind=er.independent_value,
+                dep=er.dependent_value,
+                trial=er.trial, mass=er.mass))
+
+        if not data:
+            return empty_map
+
         df = pd.DataFrame(data)
         hdict = df.groupby(['ind', 'dep'])['mass'].mean().to_dict()
+
+        if not hdict:
+            return empty_map
+
         # since floats make bad dict keys, we force them to
         # string representations. This is reliable but arbitrarily
         # limits us to 4 decimal points of precision. Not perfect,

--- a/capsim/sim/tasks.py
+++ b/capsim/sim/tasks.py
@@ -1,10 +1,10 @@
-from celery.decorators import task
+from celery import shared_task
 from django_statsd.clients import statsd
 from django.utils.encoding import smart_text
-from .models import Experiment, ExpRun, RunRecord, RunOutputRecord
+from capsim.sim.models import Experiment, ExpRun, RunRecord, RunOutputRecord
 
 
-@task
+@shared_task
 def run_experiment(experiment_id):
     statsd.incr("run_experiment")
     print("running experiment %d" % experiment_id)
@@ -12,7 +12,7 @@ def run_experiment(experiment_id):
     e.populate(callback=process_run.delay)
 
 
-@task
+@shared_task
 def generate_full_csv(experiment_id):
     statsd.incr("generate_full_csv")
     print("generating full csv")
@@ -20,7 +20,7 @@ def generate_full_csv(experiment_id):
     e.write_csv()
 
 
-@task
+@shared_task
 def process_run(run_id, exprun_id):
     statsd.incr("process_run")
     print("process_run %d, %d" % (run_id, exprun_id))

--- a/capsim/sim/tests/test_models.py
+++ b/capsim/sim/tests/test_models.py
@@ -86,11 +86,8 @@ class ExperimentTest(TestCase):
     def test_empty_heatmap(self):
         er = ExpRunFactory()
         e = er.experiment
-        try:
-            e.heatmap()
-        except KeyError:
-            # expected with no data
-            pass
+        heatmap = e.heatmap()
+        self.assertFalse(heatmap['data'])
 
 
 class TestIntervention(TestCase):

--- a/capsim/sim/tests/test_views.py
+++ b/capsim/sim/tests/test_views.py
@@ -2,9 +2,11 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client
 from capsim.sim.models import (
-    RunRecord, RunOutputRecord, Intervention, Parameter)
+    RunRecord, RunOutputRecord, Intervention, Parameter
+)
 from capsim.sim.logic import Run
 from waffle.models import Flag
+
 from .factories import ExpRunFactory
 
 
@@ -99,6 +101,7 @@ class BasicViewTest(TestCase):
 
 class ExperimentViewTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.c = Client()
         self.u = User.objects.create(username="testuser")
         self.u.set_password("test")

--- a/capsim/templates/sim/experiment_heatmap.html
+++ b/capsim/templates/sim/experiment_heatmap.html
@@ -17,6 +17,8 @@
 <td>{{col|floatformat}}</td>
 {% endfor %}
 </tr>
+{% empty %}
+Heatmap is empty &mdash; no data.
 {% endfor %}
 </tbody>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,9 +75,10 @@ vine==1.3.0
 amqp==2.6.1
 
 amqplib==1.0.2
-kombu>=3.0.37,<4.0.0
+kombu==4.6.11 # pyup: <5.0.0
 billiard==3.6.3.0
-celery>=3.1.26.post2,<4.0.0
+django-celery-results==2.0.1
+celery==4.4.7 # pyup: <5.0.0
 sqlparse==0.4.1
 decorator==4.4.2
 s3transfer==0.3.4
@@ -115,7 +116,6 @@ django-pagetree==1.4.3
 django-pageblocks==1.2.0 # pyup: <2.0.0
 django-quizblock==1.2.6
 django-markwhat==1.6.2
-django-celery==3.2.2 # pyup: <3.3.0
 text-unidecode==1.3
 Faker==6.5.0
 factory_boy==3.2.0
@@ -129,7 +129,7 @@ subprocess32==3.5.4
 
 matplotlib==3.3.4
 
-pandas<2.0.0
+pandas==1.1.5 # pyup: <1.2.0
 
 ccnmtlsettings==1.9.0
 


### PR DESCRIPTION
I changed the github actions command to `make test` because we look for
'test' in sys.argv to set up some special settings for the test celery
broker.

Also:

* Fixed an error that could occur when heatmap is empty. Instead,
  display an error that the heatmap data is empty.


Notes for merging: This will likely stall on jenkins, because jenkins isn't running rabbitmq. At that point, we can just add a rabbitmq-server instance to jenkins.

Also, after merging, we'll have to update the capsim app in salt to use the new `apps/celery4-systemd.service` file, which works with celery 4.