### PR TITLE
requirements file: remove pyup config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,10 +75,10 @@ vine==1.3.0
 amqp==2.6.1
 
 amqplib==1.0.2
-kombu==4.6.11 # pyup: <5.0.0
+kombu>=4.6.11,<5.0.0
 billiard==3.6.3.0
 django-celery-results==2.0.1
-celery==4.4.7 # pyup: <5.0.0
+celery>=4.4.7,<5.0.0
 sqlparse==0.4.1
 decorator==4.4.2
 s3transfer==0.3.4
@@ -113,7 +113,7 @@ django-stagingcontext==0.1.0
 django-impersonate==1.7.3
 django-treebeard==4.5.1
 django-pagetree==1.4.3
-django-pageblocks==1.2.0 # pyup: <2.0.0
+django-pageblocks>=1.2.0,<2.0.0
 django-quizblock==1.2.6
 django-markwhat==1.6.2
 text-unidecode==1.3
@@ -129,7 +129,7 @@ subprocess32==3.5.4
 
 matplotlib==3.3.4
 
-pandas==1.1.5 # pyup: <1.2.0
+pandas>=1.1.5,<1.2.0
 
 ccnmtlsettings==1.9.0
 


### PR DESCRIPTION
We need to pin these packages with dependabot syntax, not pyup.